### PR TITLE
chore(settings): idioma por defecto a es; desactivar Locale Middleware

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -25,7 +25,7 @@ DEBUG = env.bool("DJANGO_DEBUG", False)
 # In Windows, this must be set to your system time zone.
 TIME_ZONE = "America/Santiago"
 # https://docs.djangoproject.com/en/dev/ref/settings/#language-code
-LANGUAGE_CODE = "en-us"
+LANGUAGE_CODE = "es"
 # https://docs.djangoproject.com/en/dev/ref/settings/#site-id
 SITE_ID = 1
 # https://docs.djangoproject.com/en/dev/ref/settings/#use-i18n
@@ -134,7 +134,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.locale.LocaleMiddleware",
+    # "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",


### PR DESCRIPTION
- Cambiar el idioma por defecto a `es`, para que los formularios de autenticación estén en ese idioma.
- Teniendo en cuenta que será una app para solo clientes chilenos, desactivar el LocaleMiddleware, el cual es usado para setear el lenguaje en que se debería renderizar la página, para dejarlo siempre en español.
![image](https://user-images.githubusercontent.com/50122959/188326168-4cdefe04-6d44-4339-a09d-57d148a396e5.png)
![image](https://user-images.githubusercontent.com/50122959/188326171-a319f234-9039-44a2-947f-2cb184d943bb.png)
